### PR TITLE
Remove an extra comma that leads to JSON parse error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "Bash",
         "OCaml",
         "Lua",
-        "D",
+        "D"
     ],
     "activationEvents": [
         "onLanguage:c",


### PR DESCRIPTION
For the latest npm 7.20.5, this extra comma will lead to this error:

```
npm ERR! code EJSONPARSE
npm ERR! path /Users/symbolk/coding/vscode/syntax-highlighter/package.json
npm ERR! JSON.parse Unexpected token "]" (0x5D) in JSON at position 1239 while parsing near "...\r\n        \"D\",\r\n    ],\r\n    \"activationE..."
npm ERR! JSON.parse Failed to parse JSON data.
npm ERR! JSON.parse Note: package.json must be actual JSON, not just JavaScript.
```