### PR TITLE
Fix JS and TS grammars

### DIFF
--- a/grammars/javascript.json
+++ b/grammars/javascript.json
@@ -8,6 +8,18 @@
         "\"const\"": "modifier",
         "\"static\"": "modifier",
 
+        "this": "modifier",
+        "\"class\"": "modifier",
+        "\"function\"": "modifier",
+
+        "\"in\"": "modifier",
+        "\"instanceof\"": "modifier",
+        "\"of\"": "modifier",
+        "\"new\"": "modifier",
+        "\"typeof\"": "modifier",
+        "\"get\"": "modifier",
+        "\"set\"": "modifier",
+
         "number": "number",
         "string": "string",
         "escape_sequence": "string",
@@ -16,10 +28,10 @@
         "comment": "comment",
         "hash_bang_line": "comment",
 
-        "true": "constant",
-        "false": "constant",
-        "null": "constant",
-        "undefined": "constant",
+        "true": "constant.langauge",
+        "false": "constant.langauge",
+        "null": "constant.langauge",
+        "undefined": "constant.langauge",
 
         "\"as\"": "control",
         "\"if\"": "control",
@@ -45,18 +57,6 @@
         "\"await\"": "control",
         "\"debugger\"": "control",
         "\"delete\"": "control",
-
-        "this": "operator",
-        "\"class\"": "operator",
-        "\"function\"": "operator",
-
-        "\"in\"": "operator",
-        "\"instanceof\"": "operator",
-        "\"of\"": "operator",
-        "\"new\"": "operator",
-        "\"typeof\"": "operator",
-        "\"get\"": "operator",
-        "\"set\"": "operator",
 
         "\"=\"": "operator",
         "\"+=\"": "operator",
@@ -120,7 +120,7 @@
         "formal_parameters > identifier": "variable",
         "jsx_attribute > property_identifier": "variable",
 
-        "class > identifier": "type",
+        "class_declaration > identifier": "type",
         "new_expression > identifier": "type",
         "jsx_opening_element > identifier": "type",
         "jsx_closing_element > identifier": "type",
@@ -128,7 +128,7 @@
 
         "call_expression > identifier": "function",
         "call_expression > super": "function",
-        "function > identifier": "function",
+        "function_declaration > identifier": "function",
         "generator_function > identifier": "function",
         "method_definition > property_identifier": "function",
         "call_expression > member_expression > property_identifier": "function"

--- a/grammars/typescript.json
+++ b/grammars/typescript.json
@@ -18,6 +18,23 @@
         "\"protected\"": "modifier",
         "\"readonly\"": "modifier",
 
+        "this": "modifier",
+        "\"class\"": "modifier",
+        "\"enum\"": "modifier",
+        "\"function\"": "modifier",
+        "\"interface\"": "modifier",
+        "\"implements\"": "modifier",
+        "\"declare\"": "modifier",
+
+        "\"in\"": "modifier",
+        "\"instanceof\"": "modifier",
+        "\"of\"": "modifier",
+        "\"new\"": "modifier",
+        "\"delete\"": "modifier",
+        "\"typeof\"": "modifier",
+        "\"get\"": "modifier",
+        "\"set\"": "modifier",
+
         "number": "number",
         "string": "string",
         "escape_sequence": "string",
@@ -27,10 +44,10 @@
         "comment": "comment",
         "hash_bang_line": "comment",
 
-        "true": "constant",
-        "false": "constant",
-        "null": "constant",
-        "undefined": "constant",
+        "true": "constant.langauge",
+        "false": "constant.langauge",
+        "null": "constant.langauge",
+        "undefined": "constant.langauge",
 
         "\"as\"": "control",
         "\"if\"": "control",
@@ -55,24 +72,6 @@
         "\"async\"": "control",
         "\"await\"": "control",
         "\"debugger\"": "control",
-
-        "this": "operator",
-        "\"class\"": "operator",
-        "\"type\"": "operator",
-        "\"enum\"": "operator",
-        "\"function\"": "operator",
-        "\"interface\"": "operator",
-        "\"implements\"": "operator",
-        "\"declare\"": "operator",
-
-        "\"in\"": "operator",
-        "\"instanceof\"": "operator",
-        "\"of\"": "operator",
-        "\"new\"": "operator",
-        "\"delete\"": "operator",
-        "\"typeof\"": "operator",
-        "\"get\"": "operator",
-        "\"set\"": "operator",
 
         "\"=\"": "operator",
         "\"+=\"": "operator",
@@ -128,11 +127,11 @@
         "\"${\"": "punctuation"
     },
 
-    "complexTerms": ["identifier", "property_identifier", "super"],
+    "complexTerms": ["identifier", "property_identifier", "super", "\"type\""],
 
     "complexScopes": {
-        "class > identifier": "type",
-        "new_expression > call_expression > identifier": "type",
+        "class_declaration > identifier": "type",
+        "new_expression > identifier": "type",
         "jsx_opening_element > identifier": "type",
         "jsx_closing_element > identifier": "type",
         "jsx_self_closing_element > identifier": "type",
@@ -151,6 +150,9 @@
         "method_definition > property_identifier": "function",
         "call_expression > member_expression > property_identifier": "function",
         "method_signature > property_identifier": "function",
-        "function_signature > identifier": "function"
+        "function_declaration > identifier": "function",
+
+        "import_statement > \"type\"": "control",
+        "type_alias_declaration > \"type\"": "modifier"
     }
 }

--- a/grammars/typescriptreact.json
+++ b/grammars/typescriptreact.json
@@ -20,6 +20,23 @@
         "\"namespace\"": "modifier",
         "\"module\"": "modifier",
 
+        "this": "modifier",
+        "\"class\"": "modifier",
+        "\"enum\"": "modifier",
+        "\"function\"": "modifier",
+        "\"interface\"": "modifier",
+        "\"implements\"": "modifier",
+        "\"declare\"": "modifier",
+
+        "\"in\"": "modifier",
+        "\"instanceof\"": "modifier",
+        "\"of\"": "modifier",
+        "\"new\"": "modifier",
+        "\"delete\"": "modifier",
+        "\"typeof\"": "modifier",
+        "\"get\"": "modifier",
+        "\"set\"": "modifier",
+
         "number": "number",
         "string": "string",
         "escape_sequence": "string",
@@ -29,10 +46,10 @@
         "comment": "comment",
         "hash_bang_line": "comment",
 
-        "true": "constant",
-        "false": "constant",
-        "null": "constant",
-        "undefined": "constant",
+        "true": "constant.langauge",
+        "false": "constant.langauge",
+        "null": "constant.langauge",
+        "undefined": "constant.langauge",
 
         "\"as\"": "control",
         "\"if\"": "control",
@@ -57,24 +74,6 @@
         "\"async\"": "control",
         "\"await\"": "control",
         "\"debugger\"": "control",
-
-        "this": "operator",
-        "\"class\"": "operator",
-        "\"type\"": "operator",
-        "\"enum\"": "operator",
-        "\"function\"": "operator",
-        "\"interface\"": "operator",
-        "\"implements\"": "operator",
-        "\"declare\"": "operator",
-
-        "\"in\"": "operator",
-        "\"instanceof\"": "operator",
-        "\"of\"": "operator",
-        "\"new\"": "operator",
-        "\"delete\"": "operator",
-        "\"typeof\"": "operator",
-        "\"get\"": "operator",
-        "\"set\"": "operator",
 
         "\"=\"": "operator",
         "\"+=\"": "operator",
@@ -130,11 +129,11 @@
         "\"${\"": "punctuation"
     },
 
-    "complexTerms": ["identifier", "property_identifier", "super"],
+    "complexTerms": ["identifier", "property_identifier", "super", "\"type\""],
 
     "complexScopes": {
-        "class > identifier": "type",
-        "new_expression > call_expression > identifier": "type",
+        "class_declaration > identifier": "type",
+        "new_expression > identifier": "type",
         "jsx_opening_element > identifier": "type",
         "jsx_closing_element > identifier": "type",
         "jsx_opening_element > nested_identifier > identifier": "type",
@@ -155,6 +154,9 @@
         "method_definition > property_identifier": "function",
         "call_expression > member_expression > property_identifier": "function",
         "method_signature > property_identifier": "function",
-        "function_signature > identifier": "function"
+        "function_declaration > identifier": "function",
+
+        "import_statement > \"type\"": "control",
+        "type_alias_declaration > \"type\"": "modifier"
     }
 }


### PR DESCRIPTION
I fixed a few problems that I noticed with the JS and TS grammars. Notably, many keywords were incorrectly labeled as operators.

Before:
![image](https://user-images.githubusercontent.com/6759716/153734322-d4c5b340-fb60-4337-926c-305f2e5ac3e2.png)

After:
![image](https://user-images.githubusercontent.com/6759716/153734323-1a389809-8934-4999-a6a4-c69351a558bb.png)
