### PR TITLE
remove comma

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "Bash",
         "OCaml",
         "Lua",
-        "D",
+        "D"
     ],
     "activationEvents": [
         "onLanguage:c",


### PR DESCRIPTION
With the comma, the json doesn't validate so the package can't be compiled.