### PR TITLE
bumping typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "tree-sitter-rust": "^0.19.1",
         "tree-sitter-typescript": "^0.19.0",
         "tslint": "^6.1.2",
-        "typescript": "^3.9.3",
+        "typescript": "^4.9.3",
         "vsce": "^1.87.0"
     },
     "contributes": {


### PR DESCRIPTION
Per https://github.com/DefinitelyTyped/DefinitelyTyped/issues/63431#issuecomment-1333296828

Otherwise results in errors like
```
node_modules/@types/vscode/index.d.ts:6202:64 - error TS1005: ',' expected.

6202     export interface DiagnosticCollection extends Iterable<[uri: Uri, diagnostics: readonly Diagnostic[]]> {
```
when trying to build package with vsce.